### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` for automated dependency version updates
- Weekly schedule (Mondays), minor+patch grouped into single PRs, majors get individual PRs
- Tracks all relevant ecosystems in this repo

## Test plan
- [ ] Verify Dependabot appears under Security tab
- [ ] Confirm grouped PRs appear on next Monday (or trigger manually via Security > Dependabot)
- [ ] Verify major updates get individual PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)